### PR TITLE
Add nodejs compatibility.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,13 @@ var emitter = require('emitter-component')
 var methods = require('./methods')
 var slice = Array.prototype.slice
 
+var root = (typeof window !== 'undefined' ? window : global);
 var spying = false
 var console = (
-  'console' in window &&
-  'log' in window.console &&
-  typeof window.console.log === 'function' ?
-    window.console :
+  'console' in root &&
+  'log' in root.console &&
+  typeof root.console.log === 'function' ?
+    root.console :
     null
 )
 
@@ -40,14 +41,14 @@ emitter(ConsoleSpy.prototype)
 
 ConsoleSpy.prototype.enable = function () {
   if (!spying) {
-    window.console = this.console
+    root.console = this.console
     spying = true
   }
 }
 
 ConsoleSpy.prototype.disable = function () {
   if (spying) {
-    window.console = console
+    root.console = console
     spying = false
   }
 }


### PR DESCRIPTION
Hi,

Currently we can't use your module in `node` because it only makes a reference to `window` as the global namespace. This PR adds support to `node` environment.

Thanks!
